### PR TITLE
rudimentary version of custom configmap

### DIFF
--- a/charts/refinery/templates/configmap-rules.yaml
+++ b/charts/refinery/templates/configmap-rules.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.config.UseRulesConfigMap }}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,3 +9,5 @@ metadata:
 data:
   rules.yaml: |
 {{- toYaml .Values.rules | nindent 4 }}
+
+{{ end }}

--- a/charts/refinery/templates/configmap-rules.yaml
+++ b/charts/refinery/templates/configmap-rules.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.config.UseRulesConfigMap }}
+{{ if .Values.config.ConfigMap.Rules.Name }}
 
 apiVersion: v1
 kind: ConfigMap

--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -99,9 +99,8 @@ spec:
                   name: {{ include "refinery.fullname" . }}-config
                   items:
                     - key: config.yaml
-                      path: config.yaml
               - configMap:
-                  name: {{ include "refinery.fullname" . }}-rules
+                  name: .Values.config.UseRulesConfigMap | {{ include "refinery.fullname" . }}-rules .Values.config.CustomRulesConfigMapName
                   items:
                     - key: rules.yaml
                       path: rules.yaml

--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -101,7 +101,11 @@ spec:
                     - key: config.yaml
                       path: config.yaml
               - configMap:
-                  name: .Values.config.UseRulesConfigMap | {{ include "refinery.fullname" . }}-rules .Values.config.CustomRulesConfigMapName
+                {{- if .Values.config.ConfigMap.Rules.Name }}
+                - name: {{ .Values.config.ConfigMap.Rules.Name }}
+                {{- else }}
+                - name: {{ include "çrefinery.fullname" . }}-rules
+                {{- end }}
                   items:
                     - key: rules.yaml
                       path: rules.yaml

--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -104,7 +104,7 @@ spec:
                 {{- if .Values.config.ConfigMap.Rules.Name }}
                 - name: {{ .Values.config.ConfigMap.Rules.Name }}
                 {{- else }}
-                - name: {{ include "çrefinery.fullname" . }}-rules
+                - name: {{ include "refinery.fullname" . }}-rules
                 {{- end }}
                   items:
                     - key: rules.yaml

--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -99,6 +99,7 @@ spec:
                   name: {{ include "refinery.fullname" . }}-config
                   items:
                     - key: config.yaml
+                      path: config.yaml
               - configMap:
                   name: .Values.config.UseRulesConfigMap | {{ include "refinery.fullname" . }}-rules .Values.config.CustomRulesConfigMapName
                   items:

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -48,7 +48,7 @@ environment: [ ]
   #       name: honeycomb
   #       key: api-key
 
-# Use to map additional volumes into the Refinery pods
+# Use to map additional volumes into the Refinery pods 
 # Useful for volume-based secrets
 extraVolumeMounts: [ ]
   # - name: honeycomb-secrets
@@ -235,7 +235,7 @@ config:
   UseRulesConfigMap: true
 
   # If UseRulesConfigMap is false, set the name of your own ConfigMap to use.  
-  # CustomRulesConfigMapName: my-refinery-rules
+  # CustomRulesConfigMapName: 
 
 # Values used to build rules.yaml
 # See the example in sample-configs/rules_complete.yaml for full details on all properties

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -48,7 +48,7 @@ environment: [ ]
   #       name: honeycomb
   #       key: api-key
 
-# Use to map additional volumes into the Refinery pods 
+# Use to map additional volumes into the Refinery pods
 # Useful for volume-based secrets
 extraVolumeMounts: [ ]
   # - name: honeycomb-secrets
@@ -230,12 +230,10 @@ config:
     # listen for requests for /metrics.
     MetricsListenAddr: 0.0.0.0:9090
 
-  # Allows refinery to setup a ConfigMap with the rules defined below.  The alternative
-  # is to pass in your own ConfigMap with the rules defined there.
-  UseRulesConfigMap: true
-
-  # If UseRulesConfigMap is false, set the name of your own ConfigMap to use.  
-  # CustomRulesConfigMapName: 
+  # When Name is left blank, refinery sets up a ConfigMap with the rules defined below.  The alternative is to pass in your own ConfigMap with the rules defined there.
+  ConfigMap:
+    Rules:
+      Name: "customName"
 
 # Values used to build rules.yaml
 # See the example in sample-configs/rules_complete.yaml for full details on all properties

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -48,14 +48,14 @@ environment: [ ]
   #       name: honeycomb
   #       key: api-key
 
-# Use to map additional volumes into the Refinery pods 
+# Use to map additional volumes into the Refinery pods
 # Useful for volume-based secrets
 extraVolumeMounts: [ ]
   # - name: honeycomb-secrets
   #   mountPath: "/mnt/secrets-store"
   #   readOnly: true
 
-# Use to map additional volumes into the Refinery pods 
+# Use to map additional volumes into the Refinery pods
 extraVolumes: [ ]
   # - name: honeycomb-secrets
   #   csi:
@@ -230,6 +230,12 @@ config:
     # listen for requests for /metrics.
     MetricsListenAddr: 0.0.0.0:9090
 
+  # Allows refinery to setup a ConfigMap with the rules defined below.  The alternative
+  # is to pass in your own ConfigMap with the rules defined there.
+  UseRulesConfigMap: true
+
+  # If UseRulesConfigMap is false, set the name of your own ConfigMap to use.  
+  # CustomRulesConfigMapName: my-refinery-rules
 
 # Values used to build rules.yaml
 # See the example in sample-configs/rules_complete.yaml for full details on all properties

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -232,9 +232,9 @@ config:
 
   # When Name is left blank, refinery sets up a ConfigMap with the rules defined below.
   # The alternative is to pass in your own ConfigMap with the rules defined there.
-  # ConfigMap:
-  #   Rules:
-  #     Name:
+  ConfigMap:
+    Rules:
+      Name:
 
 # Values used to build rules.yaml
 # See the example in sample-configs/rules_complete.yaml for full details on all properties

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -230,10 +230,11 @@ config:
     # listen for requests for /metrics.
     MetricsListenAddr: 0.0.0.0:9090
 
-  # When Name is left blank, refinery sets up a ConfigMap with the rules defined below.  The alternative is to pass in your own ConfigMap with the rules defined there.
-  ConfigMap:
-    Rules:
-      Name: "customName"
+  # When Name is left blank, refinery sets up a ConfigMap with the rules defined below.
+  # The alternative is to pass in your own ConfigMap with the rules defined there.
+  # ConfigMap:
+  #   Rules:
+  #     Name:
 
 # Values used to build rules.yaml
 # See the example in sample-configs/rules_complete.yaml for full details on all properties


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

When creating sampling rules for a larger amount of datasets with Honeycomb Classic using the current method, the Values file gets larger and larger and harder to maintain.  This PR is to enable users to pass in the name of their own configmap. 

My particular use case is using Refinery as a subchart inside of a larger parent chart.  Within my own ConfigMap template, I will the be able to use templating to merge a collection of YAML within the `files/`directory of my parent chart.  This will enable the possibility of a YAML file per dataset.  They to the configmap will remain rules.yaml but the value will be templated out.

- Closes #<enter issue here>

## Short description of the changes

Using a ternary statement to use the provided rules ConfigMap name or the name of your own custom ConfigMap.  Also conditionally created the config map for rules.

## How to verify that this has the expected result
If the name for the custom configmap for rules is left blank you get

`helm template .`
...
      volumes:
        - name: refinery-config
          projected:
            sources:
              - configMap:
                  name: release-name-refinery-config
                  items:
                    - key: config.yaml
                      path: config.yaml
              - configMap:
                - name: release-name-refinery-rules
                  items:
                    - key: rules.yaml
                      path: rules.yaml

If it's set you get 

`helm template .`
...
      volumes:
        - name: refinery-config
          projected:
            sources:
              - configMap:
                  name: release-name-refinery-config
                  items:
                    - key: config.yaml
                      path: config.yaml
              - configMap:
                - name: customName
                  items:
                    - key: rules.yaml
                      path: rules.yaml